### PR TITLE
Ensure we only find ubuntu bugs

### DIFF
--- a/projects/ubuntu_project.py
+++ b/projects/ubuntu_project.py
@@ -22,6 +22,10 @@ def get(max_bug, override_result=None):
             continue
         soup = BeautifulSoup(fp.read(), "lxml")
         fp.close()
+        project = soup.select("div#watermark a")[0]["href"].split("/")[-1]
+        if project != "ubuntu":
+            print("Not ubuntu project:", project)
+            continue
         dupe = soup.select("div#bug-is-duplicate .bug-duplicate-details a")
         if dupe:
             override_result = dupe[0]["href"].split("/")[-1]


### PR DESCRIPTION
We don't want to see bugs from elementary, mint or something else. 
(we could parameterize this project and allow us to actually search for bugs in any project - such as elementary or mint)